### PR TITLE
Incorporate the migration of simulation to library, without changing API

### DIFF
--- a/imaging_sonar_simulation.orogen
+++ b/imaging_sonar_simulation.orogen
@@ -55,9 +55,7 @@ task_context "Task" do
 end
 
 task_context "ScanningSonarTask" do
-
     subclasses "imaging_sonar_simulation::Task"
-
     # Left limit angle
     property("left_limit", "base/Angle").dynamic
 
@@ -70,13 +68,14 @@ task_context "ScanningSonarTask" do
     # Enable/disable ping pong scanning mode
     property("continuous", "bool", true).dynamic
 
-    periodic 0.05
+    port_driven
 end
 
 task_context "MultibeamSonarTask" do
-
     subclasses "imaging_sonar_simulation::Task"
 
     # Number of Beams
     property("beam_count", "int", 256).dynamic
+    
+    port_driven
 end

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -24,17 +24,42 @@ MultibeamSonarTask::~MultibeamSonarTask() {
 // documentation about them.
 
 bool MultibeamSonarTask::configureHook() {
-	if (!MultibeamSonarTaskBase::configureHook())
+    if (!MultibeamSonarTaskBase::configureHook())
 		return false;
 
+    // check if the properties have valid values
+    if (_range.value() <= 0) {
+        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
+        return false;
+    }
+
+    if (_gain.value() < 0 || _gain.value() > 1) {
+        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
+        return false;
+    }
+
+    if (_bin_count.value() <= 0 || _bin_count.value() > 1500) {
+        RTT::log(RTT::Error) << "The number of bins must be positive and less than 1500." << RTT::endlog();
+        return false;
+    }
+
+    if (_beam_width.value().getRad() <= 0 || _beam_height.value().getRad() <= 0) {
+        RTT::log(RTT::Error) << "The sonar opening angles must be positives." << RTT::endlog();
+        return false;
+    }
     // check if the properties have valid values
     if (_beam_count.value() < 64 || _beam_count.value() > 512) {
         RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
         return false;
     }
-
+     
+    osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
     // set the attributes
-    sonar_sim.beam_count = _beam_count.value();
+    // generate shader world
+    uint width =  _bin_count.value() * 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim =  new gpu_sonar_simulation::SonarSimulation(_range.value(), _gain.value(), _bin_count.value(),
+            _beam_count.value(),_beam_width.value(), _beam_height.value(), 
+            width, false, root);
 
     return true;
 }
@@ -43,11 +68,7 @@ bool MultibeamSonarTask::startHook() {
 	if (!MultibeamSonarTaskBase::startHook())
 		return false;
 
-    // generate shader world
-    uint width = sonar_sim.bin_count * 5.12;  // 5.12 pixels are needed for each bin
-    Task::setupShader(width, false);
-
-    return true;
+        return true;
 }
 
 void MultibeamSonarTask::updateHook() {
@@ -55,40 +76,24 @@ void MultibeamSonarTask::updateHook() {
 
     base::samples::RigidBodyState link_pose;
 
-    if (_sonar_pose_cmd.read(link_pose) != RTT::OldData) {
-        // update sonar position
-        Task::updateSonarPose(link_pose);
+    if (_sonar_pose_cmd.read(link_pose) == RTT::NewData) {
 
-        // update the attenuation coefficient and apply the underwater absorption signal
-        double attenuation_coeff = 0;
-        if (_enable_attenuation.value()) {
-            attenuation_coeff = normal_depth_map::underwaterSignalAttenuation(
-                                        attenuation_properties.frequency,
-                                        attenuation_properties.temperature.getCelsius(),
-                                        -link_pose.position.z(),
-                                        attenuation_properties.salinity,
-                                        attenuation_properties.acidity);
-        }
-        normal_depth_map.setAttenuationCoefficient(attenuation_coeff);
-
-        // receives the shader image
-        osg::ref_ptr<osg::Image> osg_image = capture.grabImage(normal_depth_map.getNormalDepthMapNode());
-
-        // process the shader image
-        std::vector<float> bins;
-        Task::processShader(osg_image, bins);
-
-        // simulate sonar reading
-        base::samples::Sonar sonar = sonar_sim.simulateSonar(bins, range);
+        base::samples::Sonar sonar = sonar_sim->simulateSonarData(link_pose.getTransform());
 
         // set the sonar bearings
-        base::Angle interval = base::Angle::fromRad(sonar_sim.beam_width.getRad() / sonar_sim.beam_count);
-        base::Angle start = base::Angle::fromRad(-sonar_sim.beam_width.getRad() / 2);
+        base::Angle interval = base::Angle::fromRad(sonar_sim->getSonarBeamWidth().getRad() / sonar_sim->getSonarBeamCount());
+        base::Angle start = base::Angle::fromRad(-sonar_sim->getSonarBeamWidth().getRad() / 2);
         sonar.setRegularBeamBearings(start, interval);
 
         // write sonar sample in the output port
         sonar.validate();
         _sonar_samples.write(sonar);
+        
+        //display the shader image
+        std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
+        *frame = sonar_sim->getLastFrame();
+        frame->time = base::Time::now();
+        _shader_viewer.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
     }
 }
 
@@ -109,10 +114,10 @@ bool MultibeamSonarTask::setBin_count(int value) {
         RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
         return false;
     }
-    sonar_sim.bin_count = value;
-    float width = sonar_sim.bin_count * 5.12;  // 5.12 pixels are needed for each bin
-    Task::setupShader(width, false);
-    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
+    sonar_sim->setSonarBinCount(value);
+    float width = sonar_sim->getSonarBinCount()* 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim->setupShader(width, false);
+    return MultibeamSonarTaskBase::setBin_count(value);
 }
 
 bool MultibeamSonarTask::setBeam_count(int value) {
@@ -120,6 +125,25 @@ bool MultibeamSonarTask::setBeam_count(int value) {
         RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
         return false;
     }
-    sonar_sim.beam_count = value;
-    return (imaging_sonar_simulation::TaskBase::setBin_count(value));
+    sonar_sim->setSonarBeamCount(value);
+    return (MultibeamSonarTaskBase::setBeam_count(value));
+}
+
+bool MultibeamSonarTask::setRange(double value) {
+    if (value <= 0) {
+        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
+        return false;
+    }
+    sonar_sim->setRange(value);
+    return true;
+}
+
+bool MultibeamSonarTask::setGain(double value) {
+    if (value < 0 || value > 1) {
+        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
+        return false;
+    }
+
+    sonar_sim->setGain(value);
+    return true;
 }

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -26,40 +26,14 @@ MultibeamSonarTask::~MultibeamSonarTask() {
 bool MultibeamSonarTask::configureHook() {
     if (!MultibeamSonarTaskBase::configureHook())
 		return false;
-
-    // check if the properties have valid values
-    if (_range.value() <= 0) {
-        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
-        return false;
-    }
-
-    if (_gain.value() < 0 || _gain.value() > 1) {
-        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
-        return false;
-    }
-
-    if (_bin_count.value() <= 0 || _bin_count.value() > 1500) {
-        RTT::log(RTT::Error) << "The number of bins must be positive and less than 1500." << RTT::endlog();
-        return false;
-    }
-
-    if (_beam_width.value().getRad() <= 0 || _beam_height.value().getRad() <= 0) {
-        RTT::log(RTT::Error) << "The sonar opening angles must be positives." << RTT::endlog();
-        return false;
-    }
     // check if the properties have valid values
     if (_beam_count.value() < 64 || _beam_count.value() > 512) {
         RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
         return false;
     }
-     
-    osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
-    // set the attributes
-    // generate shader world
-    uint width =  _bin_count.value() * 5.12;  // 5.12 pixels are needed for each bin
-    sonar_sim =  new gpu_sonar_simulation::SonarSimulation(_range.value(), _gain.value(), _bin_count.value(),
-            _beam_count.value(),_beam_width.value(), _beam_height.value(), 
-            width, false, root);
+
+    configureSonarSimulation(false);
+    sonar_sim.setSonarBeamCount(_beam_count.value());    
 
     return true;
 }
@@ -78,11 +52,13 @@ void MultibeamSonarTask::updateHook() {
 
     if (_sonar_pose_cmd.read(link_pose) == RTT::NewData) {
 
-        base::samples::Sonar sonar = sonar_sim->simulateSonarData(link_pose.getTransform());
+        base::samples::Sonar sonar = sonar_sim.simulateSonarData(link_pose.getTransform());
 
         // set the sonar bearings
-        base::Angle interval = base::Angle::fromRad(sonar_sim->getSonarBeamWidth().getRad() / sonar_sim->getSonarBeamCount());
-        base::Angle start = base::Angle::fromRad(-sonar_sim->getSonarBeamWidth().getRad() / 2);
+        base::Angle interval = base::Angle::fromRad(
+            sonar_sim.getSonarBeamWidth().getRad() / sonar_sim.getSonarBeamCount());
+        base::Angle start = base::Angle::fromRad(
+            -sonar_sim.getSonarBeamWidth().getRad() / 2);
         sonar.setRegularBeamBearings(start, interval);
 
         // write sonar sample in the output port
@@ -91,9 +67,9 @@ void MultibeamSonarTask::updateHook() {
         
         //display the shader image
         std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
-        *frame = sonar_sim->getLastFrame();
+        *frame = sonar_sim.getLastFrame();
         frame->time = base::Time::now();
-        _shader_viewer.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
+        _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
     }
 }
 
@@ -108,42 +84,25 @@ void MultibeamSonarTask::stopHook() {
 void MultibeamSonarTask::cleanupHook() {
 	MultibeamSonarTaskBase::cleanupHook();
 }
-
 bool MultibeamSonarTask::setBin_count(int value) {
     if (value <= 0) {
         RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
         return false;
     }
-    sonar_sim->setSonarBinCount(value);
-    float width = sonar_sim->getSonarBinCount()* 5.12;  // 5.12 pixels are needed for each bin
-    sonar_sim->setupShader(width, false);
-    return MultibeamSonarTaskBase::setBin_count(value);
+
+    sonar_sim.setSonarBinCount(value);
+    float width = sonar_sim.getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim.setupShader(width, false);
+    return (MultibeamSonarTaskBase::setBin_count(value));
 }
+
+
 
 bool MultibeamSonarTask::setBeam_count(int value) {
     if (value < 64 || value > 512) {
         RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
         return false;
     }
-    sonar_sim->setSonarBeamCount(value);
+    sonar_sim.setSonarBeamCount(value);
     return (MultibeamSonarTaskBase::setBeam_count(value));
-}
-
-bool MultibeamSonarTask::setRange(double value) {
-    if (value <= 0) {
-        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
-        return false;
-    }
-    sonar_sim->setRange(value);
-    return true;
-}
-
-bool MultibeamSonarTask::setGain(double value) {
-    if (value < 0 || value > 1) {
-        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
-        return false;
-    }
-
-    sonar_sim->setGain(value);
-    return true;
 }

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -33,7 +33,7 @@ bool MultibeamSonarTask::configureHook() {
     }
 
     configureSonarSimulation(false);
-    sonar_sim.setSonarBeamCount(_beam_count.value());    
+    sonar_sim->setSonarBeamCount(_beam_count.value());    
 
     return true;
 }
@@ -52,13 +52,13 @@ void MultibeamSonarTask::updateHook() {
 
     if (_sonar_pose_cmd.read(link_pose) == RTT::NewData) {
 
-        base::samples::Sonar sonar = sonar_sim.simulateSonarData(link_pose.getTransform());
+        base::samples::Sonar sonar = sonar_sim->simulateSonarData(link_pose.getTransform());
 
         // set the sonar bearings
         base::Angle interval = base::Angle::fromRad(
-            sonar_sim.getSonarBeamWidth().getRad() / sonar_sim.getSonarBeamCount());
+            sonar_sim->getSonarBeamWidth().getRad() / sonar_sim->getSonarBeamCount());
         base::Angle start = base::Angle::fromRad(
-            -sonar_sim.getSonarBeamWidth().getRad() / 2);
+            -sonar_sim->getSonarBeamWidth().getRad() / 2);
         sonar.setRegularBeamBearings(start, interval);
 
         // write sonar sample in the output port
@@ -67,7 +67,7 @@ void MultibeamSonarTask::updateHook() {
         
         //display the shader image
         std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
-        *frame = sonar_sim.getLastFrame();
+        *frame = sonar_sim->getLastFrame();
         frame->time = base::Time::now();
         _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
     }
@@ -90,9 +90,9 @@ bool MultibeamSonarTask::setBin_count(int value) {
         return false;
     }
 
-    sonar_sim.setSonarBinCount(value);
-    float width = sonar_sim.getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
-    sonar_sim.setupShader(width, false);
+    sonar_sim->setSonarBinCount(value);
+    float width = sonar_sim->getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim->setupShader(width, false);
     return (MultibeamSonarTaskBase::setBin_count(value));
 }
 
@@ -103,6 +103,6 @@ bool MultibeamSonarTask::setBeam_count(int value) {
         RTT::log(RTT::Error) << "The number of beams must be between 64 and 512." << RTT::endlog();
         return false;
     }
-    sonar_sim.setSonarBeamCount(value);
+    sonar_sim->setSonarBeamCount(value);
     return (MultibeamSonarTaskBase::setBeam_count(value));
 }

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -66,7 +66,7 @@ void MultibeamSonarTask::updateHook() {
         _sonar_samples.write(sonar);
         
         //display the shader image
-        std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
+        std::unique_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
         *frame = sonar_sim->getLastFrame();
         frame->time = base::Time::now();
         _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));

--- a/tasks/MultibeamSonarTask.cpp
+++ b/tasks/MultibeamSonarTask.cpp
@@ -91,7 +91,7 @@ bool MultibeamSonarTask::setBin_count(int value) {
     }
 
     sonar_sim->setSonarBinCount(value);
-    float width = sonar_sim->getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    float width = sonar_sim->getSonarBinCount() * resolution_constant; 
     sonar_sim->setupShader(width, false);
     return (MultibeamSonarTaskBase::setBin_count(value));
 }

--- a/tasks/MultibeamSonarTask.hpp
+++ b/tasks/MultibeamSonarTask.hpp
@@ -4,9 +4,6 @@
 #define IMAGING_SONAR_SIMULATION_MULTIBEAMSONARTASK_TASK_HPP
 
 #include "imaging_sonar_simulation/MultibeamSonarTaskBase.hpp"
-#include <base/samples/RigidBodyState.hpp>
-#include <gpu_sonar_simulation/Sonar.hpp>
-#include <gpu_sonar_simulation/SonarSimulation.hpp>
 
 namespace imaging_sonar_simulation{
 
@@ -28,10 +25,6 @@ namespace imaging_sonar_simulation{
     {
 	friend class MultibeamSonarTaskBase;
     protected:
-         /** Sonar simulator */
-         gpu_sonar_simulation::SonarSimulation* sonar_sim;
-
-
         /** Dynamically update the number of bins
         *
         * @param value: desired number of bins
@@ -45,19 +38,6 @@ namespace imaging_sonar_simulation{
         * @return if the process is finished successfully
         */
         virtual bool setBeam_count(int value);
-        /** Dynamically update sonar range
-        *
-        * @param value: desired range
-        * @return if the process is finished successfully
-        */
-        virtual bool setRange(double value);
-
-        /** Dynamically update sonar gain
-        *
-        * @param value: desired gain
-        * @return if the process is finished successfully
-        */
-        virtual bool setGain(double value);
 
     public:
         /** TaskContext constructor for MultibeamSonarTask

--- a/tasks/MultibeamSonarTask.hpp
+++ b/tasks/MultibeamSonarTask.hpp
@@ -4,6 +4,9 @@
 #define IMAGING_SONAR_SIMULATION_MULTIBEAMSONARTASK_TASK_HPP
 
 #include "imaging_sonar_simulation/MultibeamSonarTaskBase.hpp"
+#include <base/samples/RigidBodyState.hpp>
+#include <gpu_sonar_simulation/Sonar.hpp>
+#include <gpu_sonar_simulation/SonarSimulation.hpp>
 
 namespace imaging_sonar_simulation{
 
@@ -25,6 +28,10 @@ namespace imaging_sonar_simulation{
     {
 	friend class MultibeamSonarTaskBase;
     protected:
+         /** Sonar simulator */
+         gpu_sonar_simulation::SonarSimulation* sonar_sim;
+
+
         /** Dynamically update the number of bins
         *
         * @param value: desired number of bins
@@ -38,6 +45,19 @@ namespace imaging_sonar_simulation{
         * @return if the process is finished successfully
         */
         virtual bool setBeam_count(int value);
+        /** Dynamically update sonar range
+        *
+        * @param value: desired range
+        * @return if the process is finished successfully
+        */
+        virtual bool setRange(double value);
+
+        /** Dynamically update sonar gain
+        *
+        * @param value: desired gain
+        * @return if the process is finished successfully
+        */
+        virtual bool setGain(double value);
 
     public:
         /** TaskContext constructor for MultibeamSonarTask

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -181,7 +181,7 @@ bool ScanningSonarTask::setBin_count(int value) {
     }
 
     sonar_sim->setSonarBinCount(value);
-    float height = sonar_sim->getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    float height = sonar_sim->getSonarBinCount() * resolution_constant;
     sonar_sim->setupShader(height, true);
     return (ScanningSonarTaskBase::setBin_count(value));
 }

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -35,45 +35,19 @@ bool ScanningSonarTask::configureHook() {
 	if (!ScanningSonarTaskBase::configureHook())
 		return false;
     // check if the properties have valid values
-    if (_range.value() <= 0) {
-        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
-        return false;
-    }
-
-    if (_gain.value() < 0 || _gain.value() > 1) {
-        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
-        return false;
-    }
-
-    if (_bin_count.value() <= 0 || _bin_count.value() > 1500) {
-        RTT::log(RTT::Error) << "The number of bins must be positive and less than 1500." << RTT::endlog();
-        return false;
-    }
-
-    if (_beam_width.value().getRad() <= 0 || _beam_height.value().getRad() <= 0) {
-        RTT::log(RTT::Error) << "The sonar opening angles must be positives." << RTT::endlog();
-        return false;
-    }
-
-    
-    // check if the properties have valid values
     if (_motor_step.value().getRad() <= 0 || _motor_step.value() > base::Angle::fromDeg(3.6)) {
         RTT::log(RTT::Error) << "The step angle value must be positive and less or equal than 3.6 degrees." << RTT::endlog();
         return false;
     }
 
+    configureSonarSimulation(true);
     // set attributes
     left_limit = _left_limit.value();
     right_limit = _right_limit.value();
     motor_step = _motor_step.value();
     continuous = _continuous.value();
-    
-    osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
-    // generate shader world
-    int height = _bin_count.value() * 5.12;    // 5.12 pixels are needed for each bin
-    sonar_sim = new gpu_sonar_simulation::SonarSimulation(_range.value(), _gain.value(), _bin_count.value(),
-            1,_beam_width.value(), _beam_height.value(), 
-            height, true, root);
+
+    sonar_sim.setSonarBeamCount(1);    
 
     return true;
 }
@@ -95,8 +69,16 @@ void ScanningSonarTask::updateHook() {
     base::samples::RigidBodyState link_pose;
 
     if (_sonar_pose_cmd.read(link_pose) == RTT::NewData) {
+        sonar_sim.setAttenuationCoefficient(attenuation_properties.frequency,
+                                        attenuation_properties.temperature.getCelsius(),
+                                        -link_pose.position.z(),
+                                        attenuation_properties.salinity,
+                                        attenuation_properties.acidity);
+         
+        sonar_sim.enableSpeckleNoise(_enable_speckle_noise.value());
+        base::samples::RigidBodyState sonar_pose = rotatePose(link_pose);
         base::samples::Sonar sonar = 
-            sonar_sim->simulateSonarData(sonar_pose.getTransform());
+            sonar_sim.simulateSonarData(sonar_pose.getTransform());
 
         // set the sonar bearing
         sonar.bearings.push_back(current_bearing);
@@ -106,9 +88,9 @@ void ScanningSonarTask::updateHook() {
 
         //display the shader image
         std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
-        *frame = sonar_sim->getLastFrame();
+        *frame = sonar_sim.getLastFrame();
         frame->time = base::Time::now();
-        _shader_viewer.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
+        _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
 
         // move the head position
         moveHeadPosition();
@@ -198,27 +180,9 @@ bool ScanningSonarTask::setBin_count(int value) {
         return false;
     }
 
-    sonar_sim->setSonarBinCount(value);
-    float height = sonar_sim->getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
-    sonar_sim->setupShader(height, true);
+    sonar_sim.setSonarBinCount(value);
+    float height = sonar_sim.getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim.setupShader(height, true);
     return (ScanningSonarTaskBase::setBin_count(value));
 }
 
-
-bool ScanningSonarTask::setRange(double value) {
-    if (value <= 0) {
-        RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
-        return false;
-    }
-    sonar_sim->setRange(value);
-    return true;
-}
-
-bool ScanningSonarTask::setGain(double value) {
-    if (value < 0 || value > 1) {
-        RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
-        return false;
-    }
-    sonar_sim->setGain(value);
-    return true;
-}

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -87,7 +87,7 @@ void ScanningSonarTask::updateHook() {
         _sonar_samples.write(sonar);
 
         //display the shader image
-        std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
+        std::unique_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
         *frame = sonar_sim->getLastFrame();
         frame->time = base::Time::now();
         _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));

--- a/tasks/ScanningSonarTask.cpp
+++ b/tasks/ScanningSonarTask.cpp
@@ -47,7 +47,7 @@ bool ScanningSonarTask::configureHook() {
     motor_step = _motor_step.value();
     continuous = _continuous.value();
 
-    sonar_sim.setSonarBeamCount(1);    
+    sonar_sim->setSonarBeamCount(1);    
 
     return true;
 }
@@ -69,16 +69,16 @@ void ScanningSonarTask::updateHook() {
     base::samples::RigidBodyState link_pose;
 
     if (_sonar_pose_cmd.read(link_pose) == RTT::NewData) {
-        sonar_sim.setAttenuationCoefficient(attenuation_properties.frequency,
+        sonar_sim->setAttenuationCoefficient(attenuation_properties.frequency,
                                         attenuation_properties.temperature.getCelsius(),
                                         -link_pose.position.z(),
                                         attenuation_properties.salinity,
                                         attenuation_properties.acidity);
          
-        sonar_sim.enableSpeckleNoise(_enable_speckle_noise.value());
+        sonar_sim->enableSpeckleNoise(_enable_speckle_noise.value());
         base::samples::RigidBodyState sonar_pose = rotatePose(link_pose);
         base::samples::Sonar sonar = 
-            sonar_sim.simulateSonarData(sonar_pose.getTransform());
+            sonar_sim->simulateSonarData(sonar_pose.getTransform());
 
         // set the sonar bearing
         sonar.bearings.push_back(current_bearing);
@@ -88,7 +88,7 @@ void ScanningSonarTask::updateHook() {
 
         //display the shader image
         std::auto_ptr<base::samples::frame::Frame> frame(new base::samples::frame::Frame());
-        *frame = sonar_sim.getLastFrame();
+        *frame = sonar_sim->getLastFrame();
         frame->time = base::Time::now();
         _shader_image.write(RTT::extras::ReadOnlyPointer<base::samples::frame::Frame>(frame.release()));
 
@@ -180,9 +180,9 @@ bool ScanningSonarTask::setBin_count(int value) {
         return false;
     }
 
-    sonar_sim.setSonarBinCount(value);
-    float height = sonar_sim.getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
-    sonar_sim.setupShader(height, true);
+    sonar_sim->setSonarBinCount(value);
+    float height = sonar_sim->getSonarBinCount() * 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim->setupShader(height, true);
     return (ScanningSonarTaskBase::setBin_count(value));
 }
 

--- a/tasks/ScanningSonarTask.hpp
+++ b/tasks/ScanningSonarTask.hpp
@@ -4,6 +4,10 @@
 #define IMAGING_SONAR_SIMULATION_SCANNINGSONARTASK_TASK_HPP
 
 #include "imaging_sonar_simulation/ScanningSonarTaskBase.hpp"
+// Rock includes
+#include <base/samples/RigidBodyState.hpp>
+#include <gpu_sonar_simulation/Sonar.hpp>
+#include <gpu_sonar_simulation/SonarSimulation.hpp>
 
 namespace imaging_sonar_simulation {
 
@@ -25,7 +29,11 @@ class ScanningSonarTask: public ScanningSonarTaskBase {
 	friend class ScanningSonarTaskBase;
 
 protected:
-    /** The left limit angle of sonar reading */
+
+     /** Sonar simulator */
+     gpu_sonar_simulation::SonarSimulation* sonar_sim;
+
+     /** The left limit angle of sonar reading */
     base::Angle left_limit;
 
     /** The right limit angle of sonar reading */
@@ -88,8 +96,22 @@ protected:
     * @return if the process is finished successfully
     */
     virtual bool setBin_count(int value);
+    /** Dynamically update sonar range
+    *
+    * @param value: desired range
+    * @return if the process is finished successfully
+    */
+    virtual bool setRange(double value);
+
+    /** Dynamically update sonar gain
+    *
+    * @param value: desired gain
+    * @return if the process is finished successfully
+    */
+    virtual bool setGain(double value);
 
 public:
+
 	/** TaskContext constructor for ScanningSonarTask
 	 * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
 	 * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.

--- a/tasks/ScanningSonarTask.hpp
+++ b/tasks/ScanningSonarTask.hpp
@@ -30,9 +30,6 @@ class ScanningSonarTask: public ScanningSonarTaskBase {
 
 protected:
 
-     /** Sonar simulator */
-     gpu_sonar_simulation::SonarSimulation* sonar_sim;
-
      /** The left limit angle of sonar reading */
     base::Angle left_limit;
 
@@ -96,19 +93,6 @@ protected:
     * @return if the process is finished successfully
     */
     virtual bool setBin_count(int value);
-    /** Dynamically update sonar range
-    *
-    * @param value: desired range
-    * @return if the process is finished successfully
-    */
-    virtual bool setRange(double value);
-
-    /** Dynamically update sonar gain
-    *
-    * @param value: desired gain
-    * @return if the process is finished successfully
-    */
-    virtual bool setGain(double value);
 
 public:
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -10,6 +10,7 @@
 using namespace imaging_sonar_simulation;
 using namespace base::samples::frame;
 
+
 Task::Task(std::string const& name) :
 		TaskBase(name),
         sonar_sim(nullptr) {
@@ -82,7 +83,7 @@ void Task::configureSonarSimulation(bool isScanning)
 {
     osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
     // generate shader world
-    int value = _bin_count.value() * 5.12;    // 5.12 pixels are needed for each bin
+    int value = _bin_count.value() * resolution_constant;
     sonar_sim = new gpu_sonar_simulation::SonarSimulation(_range.value(), _gain.value(), _bin_count.value(),
             _beam_width.value(), _beam_height.value(), value, isScanning, root);
     // set the attributes
@@ -103,9 +104,9 @@ void Task::stopHook() {
 	TaskBase::stopHook();
 }
 void Task::cleanupHook() {
-	TaskBase::cleanupHook();
     delete sonar_sim;
     sonar_sim = nullptr;
+	TaskBase::cleanupHook();
 }
 
 bool Task::setRange(double value) {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -70,18 +70,24 @@ bool Task::configureHook() {
         RTT::log(RTT::Error) << "The water acidity must have pH between 7.7 and 8.3." << RTT::endlog();
         return false;
     }
-
     // set the attributes
-    range = _range.value();
-    gain = _gain.value();
-    normal_depth_map.setMaxRange(_range.value());
-    sonar_sim.bin_count = _bin_count.value();
-    sonar_sim.beam_width = _beam_width.value();
-    sonar_sim.beam_height = _beam_height.value();
     attenuation_properties = _attenuation_properties.value();
 
 	return true;
 }
+
+bool Task::configureSonarSimulation(bool isScanning)
+{
+    osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
+    // generate shader world
+    int value = _bin_count.value() * 5.12;    // 5.12 pixels are needed for each bin
+    sonar_sim.init(_range.value(), _gain.value(), _bin_count.value(),
+            _beam_width.value(), _beam_height.value(), value, isScanning, root);
+    // set the attributes
+
+	return true;
+}
+
 bool Task::startHook() {
 	if (!TaskBase::startHook())
 		return false;
@@ -100,73 +106,12 @@ void Task::cleanupHook() {
 	TaskBase::cleanupHook();
 }
 
-void Task::setupShader(uint value, bool isHeight) {
-    double const half_fovx = sonar_sim.beam_width.getRad() / 2;
-    double const half_fovy = sonar_sim.beam_height.getRad() / 2;
-
-    // initialize shader (NormalDepthMap and ImageViewerCaptureTool)
-    normal_depth_map = normal_depth_map::NormalDepthMap(range, half_fovx, half_fovy);
-    capture = normal_depth_map::ImageViewerCaptureTool(sonar_sim.beam_height.getRad(), sonar_sim.beam_width.getRad(), value, isHeight);
-    capture.setBackgroundColor(osg::Vec4d(0.0, 0.0, 0.0, 1.0));
-    osg::ref_ptr<osg::Group> root = vizkit3dWorld->getWidget()->getRootNode();
-    normal_depth_map.addNodeChild(root);
-}
-
-void Task::updateSonarPose(base::samples::RigidBodyState pose) {
-    // convert OSG (Z-forward) to RoCK coordinate system (X-forward)
-    osg::Matrixd rock_coordinate_matrix = osg::Matrixd::rotate( M_PI_2, osg::Vec3(0, 0, 1)) * osg::Matrixd::rotate(-M_PI_2, osg::Vec3(1, 0, 0));
-
-    // transformation matrixes multiplication
-    osg::Matrixd matrix;
-    matrix.setTrans(osg::Vec3(pose.position.x(), pose.position.y(), pose.position.z()));
-    matrix.setRotate(osg::Quat(pose.orientation.x(), pose.orientation.y(), pose.orientation.z(), pose.orientation.w()));
-    matrix.invert(matrix);
-
-    // correct coordinate system and apply geometric transformations
-    osg::Matrixd m = matrix * rock_coordinate_matrix;
-    osg::Vec3 eye, center, up;
-    m.getLookAt(eye, center, up);
-    capture.setCameraPosition(eye, center, up);
-}
-
-void Task::processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins) {
-    // receives shader image in opencv format
-    cv::Mat cv_image, cv_depth;
-    gpu_sonar_simulation::convertOSG2CV(osg_image, cv_image);
-    osg::ref_ptr<osg::Image> osg_depth = capture.getDepthBuffer();
-    gpu_sonar_simulation::convertOSG2CV(osg_depth, cv_depth);
-
-    // replace depth matrix
-    std::vector<cv::Mat> channels;
-    cv::split(cv_image, channels);
-    channels[1] = cv_depth;
-    cv::merge(channels, cv_image);
-
-    // decode shader informations to sonar data
-    sonar_sim.decodeShader(cv_image, bins, _enable_speckle_noise.value());
-
-    // apply the additional gain
-    sonar_sim.applyAdditionalGain(bins, gain);
-
-    // display shader image
-    if (_write_shader_image.value()) {
-        std::unique_ptr<Frame> frame(new Frame());
-        cv_image.convertTo(cv_image, CV_8UC3, 255);
-        cv::flip(cv_image, cv_image, 0);
-        frame_helper::FrameHelper::copyMatToFrame(cv_image, *frame.get());
-        frame->time = base::Time::now();
-        _shader_image.write(RTT::extras::ReadOnlyPointer<Frame>(frame.release()));
-    }
-}
-
 bool Task::setRange(double value) {
     if (value <= 0) {
         RTT::log(RTT::Error) << "The range must be positive." << RTT::endlog();
         return false;
     }
-
-    range = value;
-    normal_depth_map.setMaxRange(value);
+    sonar_sim.setRange(value);
     return (imaging_sonar_simulation::TaskBase::setRange(value));
 }
 
@@ -175,8 +120,7 @@ bool Task::setGain(double value) {
         RTT::log(RTT::Error) << "The gain must be between 0.0 and 1.0." << RTT::endlog();
         return false;
     }
-
-    gain = value;
+    sonar_sim.setGain(value);
     return (imaging_sonar_simulation::TaskBase::setGain(value));
 }
 
@@ -203,4 +147,15 @@ bool Task::setAttenuation_properties(::imaging_sonar_simulation::AcousticAttenua
 
     attenuation_properties = value;
     return (imaging_sonar_simulation::TaskBase::setAttenuation_properties(value));
+}
+
+bool Task::setBin_count(int value) {
+    if (value <= 0) {
+        RTT::log(RTT::Error) << "The number of bins must be positive." << RTT::endlog();
+        return false;
+    }
+    sonar_sim.setSonarBinCount(value);
+    float width = sonar_sim.getSonarBinCount()* 5.12;  // 5.12 pixels are needed for each bin
+    sonar_sim.setupShader(width, false);
+    return TaskBase::setBin_count(value);
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -6,11 +6,9 @@
 #include "imaging_sonar_simulation/TaskBase.hpp"
 
 // Rock includes
-#include <base/samples/RigidBodyState.hpp>
 #include <gpu_sonar_simulation/Sonar.hpp>
-#include <normal_depth_map/NormalDepthMap.hpp>
-#include <normal_depth_map/ImageViewerCaptureTool.hpp>
-#include <normal_depth_map/Tools.hpp>
+#include <gpu_sonar_simulation/SonarSimulation.hpp>
+#include <base/samples/RigidBodyState.hpp>
 
 namespace imaging_sonar_simulation{
 
@@ -33,7 +31,7 @@ namespace imaging_sonar_simulation{
 	friend class TaskBase;
     protected:
         /** Sonar simulator */
-        gpu_sonar_simulation::Sonar sonar_sim;
+        gpu_sonar_simulation::SonarSimulation sonar_sim;
 
         /** Range value used by sonar simulator (in meters) */
         double range;
@@ -44,53 +42,6 @@ namespace imaging_sonar_simulation{
         /** Underwater acoustic attenuation properties */
         AcousticAttenuationProperties attenuation_properties;
 
-        /** Normal and depth map from an osg scene. */
-        normal_depth_map::NormalDepthMap normal_depth_map;
-
-        /** Capture the osg::Image from a node scene */
-        normal_depth_map::ImageViewerCaptureTool capture;
-
-        /**
-        *  Initialize shader.
-        *  @param value: size of width/height of shader image in pixels
-        *  @param isHeight: if true, the value is related with image height
-        *                   otherwise, the vale is related with image width
-        */
-        void setupShader(uint value, bool isHeight = true);
-
-        /**
-        *  Update sonar pose according to auv pose.
-        *  @param pose: pose of the auv
-        */
-        void updateSonarPose(base::samples::RigidBodyState pose);
-
-        /**
-        *  Process shader image in bins intensity.
-        *  @param osg_image: the shader image (normal, depth and angle informations) in osg::Image format
-        *  @param bins: the output simulated sonar data (all beams) in float
-        */
-        void processShader(osg::ref_ptr<osg::Image>& osg_image, std::vector<float>& bins);
-
-        /** Dynamically update sonar range
-        *
-        * @param value: desired range
-        * @return if the process is finished successfully
-        */
-        virtual bool setRange(double value);
-
-        /** Dynamically update sonar gain
-        *
-        * @param value: desired gain
-        * @return if the process is finished successfully
-        */
-        virtual bool setGain(double value);
-
-        /** Dynamically update underwater acoustic attenuation properties
-        *
-        * @param value: desired configuration
-        * @return if the process is finished successfully
-        */
-        virtual bool setAttenuation_properties(::imaging_sonar_simulation::AcousticAttenuationProperties const & value);
 
     public:
         /** TaskContext constructor for Task
@@ -108,7 +59,31 @@ namespace imaging_sonar_simulation{
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~Task();
+        
+        /** Dynamically update underwater acoustic attenuation properties
+        *
+        * @param value: desired configuration
+        * @return if the process is finished successfully
+        */
+        virtual bool setAttenuation_properties( 
+            ::imaging_sonar_simulation::AcousticAttenuationProperties const & value);
+        
+        /** Dynamically update sonar range
+        *
+        * @param value: desired range
+        * @return if the process is finished successfully
+        */
+        virtual bool setRange(double value);
+
+        /** Dynamically update sonar gain
+        *
+        * @param value: desired gain
+        * @return if the process is finished successfully
+        */
+        virtual bool setGain(double value);
+
+        virtual bool setBin_count(int value);
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -125,6 +100,8 @@ namespace imaging_sonar_simulation{
          \endverbatim
          */
         bool configureHook();
+
+        bool configureSonarSimulation( bool isScanning);
 
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to Running. If it returns false, then the component will

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -31,7 +31,7 @@ namespace imaging_sonar_simulation{
 	friend class TaskBase;
     protected:
         /** Sonar simulator */
-        gpu_sonar_simulation::SonarSimulation sonar_sim;
+        gpu_sonar_simulation::SonarSimulation* sonar_sim;
 
         /** Range value used by sonar simulator (in meters) */
         double range;
@@ -83,8 +83,6 @@ namespace imaging_sonar_simulation{
         */
         virtual bool setGain(double value);
 
-        virtual bool setBin_count(int value);
-
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
          * component will stay in PreOperational. Otherwise, it goes into
@@ -101,7 +99,7 @@ namespace imaging_sonar_simulation{
          */
         bool configureHook();
 
-        bool configureSonarSimulation( bool isScanning);
+        void configureSonarSimulation( bool isScanning);
 
         /** This hook is called by Orocos when the state machine transitions
          * from Stopped to Running. If it returns false, then the component will

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -12,6 +12,7 @@
 
 namespace imaging_sonar_simulation{
 
+    static constexpr float resolution_constant = 5.12;
     /*! \class Task
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ThirteenLtda/simulation-gpu_sonar_simulation/pull/2